### PR TITLE
STRY50374949: Support SSH for Basic authentication (without MID server)

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/transport/TransportGitSsh.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/transport/TransportGitSsh.java
@@ -48,6 +48,7 @@ package org.eclipse.jgit.transport;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.security.AccessControlException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -208,8 +209,16 @@ public class TransportGitSsh extends SshTransport implements PackTransport {
 		return new NoRemoteRepositoryException(uri, why);
 	}
 
+	/**
+	 * Added a try/catch to return false if cannot access the environment variable.
+	 * @return
+	 */
 	private static boolean useExtSession() {
-		return SystemReader.getInstance().getenv("GIT_SSH") != null; //$NON-NLS-1$
+		try {
+			return SystemReader.getInstance().getenv("GIT_SSH") != null; //$NON-NLS-1$
+		} catch (AccessControlException e){
+			return false;
+		}
 	}
 
 	private class ExtSession implements RemoteSession {


### PR DESCRIPTION
Support SSH for Basic authentication (without MID server)

+ On the instance we do not want to grant access to GIT_SSH environment variable. Adding a try/catch to not make it fail.