### PR TITLE
Fixed NullPointerException when saving .jgitconfig file

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/util/SystemReader.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/util/SystemReader.java
@@ -51,9 +51,9 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
-//import java.nio.file.InvalidPathException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-//import java.nio.file.Paths;
+import java.nio.file.Paths;
 import java.security.AccessControlException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -151,7 +151,7 @@ public abstract class SystemReader {
 		}
 
 		private Path getXDGConfigHome(FS fs) {
-			/*String configHomePath = getenv(Constants.XDG_CONFIG_HOME);
+			String configHomePath = getenv(Constants.XDG_CONFIG_HOME);
 			if (StringUtils.isEmptyOrNull(configHomePath)) {
 				configHomePath = new File(fs.userHome(), ".config") //$NON-NLS-1$
 						.getAbsolutePath();
@@ -163,7 +163,7 @@ public abstract class SystemReader {
 			} catch (IOException | InvalidPathException e) {
 				LOG.error(JGitText.get().createXDGConfigHomeFailed,
 						configHomePath, e);
-			}*/
+			}
 			return null;
 		}
 


### PR DESCRIPTION
Fix the following NullPointerException:
[SEVERE] java.lang.NullPointerException (org.eclipse.jgit.util.FS$FileStoreAttributes#lambda$2)
 java.util.concurrent.CompletionException: java.lang.NullPointerException
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273)
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:280)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1592)
	at java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1582)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
Caused by: java.lang.NullPointerException
	at org.eclipse.jgit.util.FileUtils.mkdirs(FileUtils.java:422)
	at org.eclipse.jgit.internal.storage.file.LockFile.lock(LockFile.java:163)
	at org.eclipse.jgit.storage.file.FileBasedConfig.save(FileBasedConfig.java:252)
	at org.eclipse.jgit.util.FS$FileStoreAttributes.saveToConfig(FS.java:584)
	at org.eclipse.jgit.util.FS$FileStoreAttributes.lambda$0(FS.java:365)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590)
	... 5 more