### PR TITLE
STRY51783300: Modify hidden file removal to avoid formatting ADD/DELETE differences

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/api/DiffCommand.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/api/DiffCommand.java
@@ -132,7 +132,7 @@ public class DiffCommand extends GitCommand<List<DiffEntry>> {
 			if (sourcePrefix != null) {
 				diffFmt.setOldPrefix(sourcePrefix);
 			}
-			diffFmt.format(result, this.getDeltaFilterPattern());
+			diffFmt.filterHiddenFiles(result, this.getDeltaFilterPattern());
 			diffFmt.flush();
 			return result;
 		} catch (IOException e) {

--- a/org.eclipse.jgit/src/org/eclipse/jgit/diff/DiffFormatter.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/diff/DiffFormatter.java
@@ -725,6 +725,34 @@ public class DiffFormatter implements AutoCloseable {
 		}
 	}
 
+	/**
+	 * Format the diff entries by filtering out the noise from the given delta filter pattern
+	 * The filter acts only for files that have MODIFY change Type.
+	 * If there are no changes detected, we will remove the diff entry.
+	 * @param entries
+	 * @param deltaFilterPattern
+	 * @throws IOException
+	 */
+
+	public void filterHiddenFiles(List<? extends DiffEntry> entries, Pattern deltaFilterPattern) throws IOException {
+		if (deltaFilterPattern == null)
+			return;
+
+		Iterator<? extends DiffEntry> diIterator = entries.iterator();
+		while (diIterator.hasNext()) {
+			DiffEntry diffEntry = diIterator.next();
+			if (MODIFY.equals(diffEntry.changeType)) {
+				FormatResult res = createFormatResult(diffEntry);
+				String aContent = new String(res.a.content);
+				String bContent = new String(res.b.content);
+				aContent = deltaFilterPattern.matcher(aContent).replaceAll(EMPTY_STRING);
+				bContent = deltaFilterPattern.matcher(bContent).replaceAll(EMPTY_STRING);
+				if (aContent.equals(bContent))
+					diIterator.remove();
+			}
+		}
+	}
+
 
 	/**
 	 * Format a patch script for one file entry.

--- a/org.eclipse.jgit/src/org/eclipse/jgit/diff/DiffFormatter.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/diff/DiffFormatter.java
@@ -734,7 +734,7 @@ public class DiffFormatter implements AutoCloseable {
 	 * @throws IOException
 	 */
 
-	public void filterHiddenFiles(List<? extends DiffEntry> entries, Pattern deltaFilterPattern) throws IOException {
+	public void filterModifiedFiles(List<? extends DiffEntry> entries, Pattern deltaFilterPattern) throws IOException {
 		if (deltaFilterPattern == null)
 			return;
 


### PR DESCRIPTION
Modify JGIT format method to avoid formatting ADD/DELETE changes during GitDiff calculation to improve export app performance

[Story](https://buildtools1.service-now.com/nav_to.do?uri=rm_story.do?sys_id=ef7d7a29db692490bc2e9b3c8a9619eb%26sysparm_view=scrum)
[Spike](https://buildtools1.service-now.com/nav_to.do?uri=rm_story.do?sys_id=9dc0c142dbbc20d07a4c0f4dca9619ac%26sysparm_view=scrum)